### PR TITLE
fix invisible panel focused border

### DIFF
--- a/themes/quiet-light.json
+++ b/themes/quiet-light.json
@@ -60,7 +60,7 @@
 				"tab.active_background": "#F5F5F5",
 				"search.match_background": "#edc9d899",
 				"panel.background": "#F1F0F2",
-				"panel.focused_border": "#9769dc00",
+				"panel.focused_border": "#C9D0D9a0",
 				"pane.focused_border": "#9769dc00",
 				"scrollbar.thumb.background": "#bbbbbbc0",
 				"scrollbar.thumb.hover_background": "#F5F5F5",


### PR DESCRIPTION
👋 Thanks for this port of my favorite light theme!

This PR adds a border to the focused panel element, so we can navigate easily with the keyboard (was transparent)

https://github.com/user-attachments/assets/d1b58bc8-7770-4102-a35f-1caa0ad32de4

